### PR TITLE
Switch to Docker-based server with HTTP client

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to ClawHub
+name: Publish to OpenClaw Hub
 
 on:
   release:
@@ -19,8 +19,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install ClawHub CLI
-        run: npm install -g clawhub
+      - name: Install OpenClaw Hub CLI
+        run: npm install -g openclaw
 
       - name: Determine version
         id: version
@@ -35,12 +35,12 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
 
-      - name: Publish to ClawHub
+      - name: Publish to OpenClaw Hub
         env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+          OPENCLAW_TOKEN: ${{ secrets.OPENCLAW_TOKEN }}
         run: |
-          clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-          clawhub publish . \
+          openclaw login --token "$OPENCLAW_TOKEN" --no-browser
+          openclaw publish . \
             --slug read-no-evil-mcp \
             --name "read-no-evil-mcp" \
             --version "${{ steps.version.outputs.version }}" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to OpenClaw Hub
+name: Publish to ClawHub
 
 on:
   release:
@@ -19,8 +19,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install OpenClaw Hub CLI
-        run: npm install -g openclaw
+      - name: Install ClawHub CLI
+        run: npm install -g clawhub
 
       - name: Determine version
         id: version
@@ -35,12 +35,12 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
 
-      - name: Publish to OpenClaw Hub
+      - name: Publish to ClawHub
         env:
-          OPENCLAW_TOKEN: ${{ secrets.OPENCLAW_TOKEN }}
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
-          openclaw login --token "$OPENCLAW_TOKEN" --no-browser
-          openclaw publish . \
+          clawhub login --token "$CLAWHUB_TOKEN" --no-browser
+          clawhub publish . \
             --slug read-no-evil-mcp \
             --name "read-no-evil-mcp" \
             --version "${{ steps.version.outputs.version }}" \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 🙈 *"Read no evil"* — Secure email access for your AI agent, with prompt injection protection built in.
 
-This is an [OpenClaw](https://openclaw.ai) skill published on [ClawHub](https://clawhub.ai). Your agent can read, send, and manage emails without worrying about prompt injection attacks hiding in message content.
+This is an [OpenClaw](https://openclaw.ai) skill — your agent can read, send, and manage emails without you worrying about prompt injection attacks hiding in message content.
 
 ## Install
 
@@ -26,6 +26,8 @@ This skill connects to a [read-no-evil-mcp](https://github.com/thekie/read-no-ev
 - 👥 **Multiple accounts** — Connect as many email accounts as you need, each with its own permissions and rules
 - 🐍 **Nothing to install** — Works out of the box with no extra dependencies
 
+For the full feature set, head over to [read-no-evil-mcp](https://github.com/thekie/read-no-evil-mcp).
+
 ## 🔐 Security
 
 Every email is scanned by a [DeBERTa-based ML model](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2) before reaching your agent. Scanning is never skipped, even for trusted senders. Your credentials never leave the server.
@@ -38,11 +40,3 @@ Every email is scanned by a [DeBERTa-based ML model](https://huggingface.co/prot
 ## License
 
 Apache 2.0 — See [LICENSE](LICENSE)
-
----
-
-<p align="center">
-  <b>🙈 🙉 🙊</b><br>
-  <i>See no evil. Hear no evil. Speak no evil.</i><br>
-  <i>Read no evil.</i>
-</p>

--- a/README.md
+++ b/README.md
@@ -1,146 +1,57 @@
-# OpenClaw Skill: read-no-evil-mcp
+# 🦞 read-no-evil-mcp
 
-Secure email access for [OpenClaw](https://github.com/openclaw/openclaw) with prompt injection protection.
+**Secure email access for your AI agent — with prompt injection protection built in.**
 
-Uses [read-no-evil-mcp](https://github.com/thekie/read-no-evil-mcp) to scan emails for prompt injection attacks before your AI agent sees them.
+Your [Clawbot](https://clawhub.ai) agent can read, send, and manage emails without worrying about prompt injection attacks hiding in message content.
 
 ## Features
 
-- Secure email access: list, read, send, move, and delete emails
-- Automatic prompt injection detection (server-side ML scanning)
-- Full credential isolation — the AI agent never sees passwords or email server connections
-- Zero dependencies — uses only Python stdlib (3.8+)
+- 📧 List, read, send, move, and delete emails via a secure gateway
+- 🛡️ Automatic prompt injection detection using ML — malicious emails are flagged before your agent sees them
+- 🔒 Full credential isolation — your passwords and email connections never touch the AI agent
+- ⚙️ Configurable permissions per account (read-only, send, delete, move)
+- 🐍 Zero dependencies — pure Python stdlib, no pip install needed
 
-## Architecture
-
-This skill is a thin HTTP client that speaks the [MCP Streamable HTTP protocol](https://modelcontextprotocol.io/) to a read-no-evil-mcp server. All email operations, credential management, and prompt injection scanning happen on the server side.
-
-```
-OpenClaw Agent  -->  rnoe-mail.py (HTTP client)  -->  read-no-evil-mcp server  -->  IMAP/SMTP
-```
-
-## Installation
-
-### Via OpenClaw Hub
-```bash
-openclaw install read-no-evil-mcp
-```
-
-### Manual
-```bash
-git clone https://github.com/thekie/read-no-evil-openclaw-skill.git ~/.openclaw/skills/read-no-evil-mcp
-```
-
-No `pip install` required.
-
-## Configuration
-
-Before starting the server, create a config file for your email accounts:
+## Install
 
 ```bash
-# Interactive wizard — creates ~/.config/read-no-evil-mcp/config.yaml
-scripts/setup-config.py create
-
-# Add another account to existing config
-scripts/setup-config.py add
-
-# List configured accounts
-scripts/setup-config.py list
-
-# Remove an account
-scripts/setup-config.py remove <account-id>
-
-# Show full config
-scripts/setup-config.py show
+clawhub install read-no-evil-mcp
 ```
 
-The wizard includes provider presets for Gmail, Outlook, and Yahoo with auto-detected IMAP/SMTP settings. It will also offer to create a `.env` file with password placeholder variables.
-
-Passwords are never stored in the config file. They are passed as environment variables:
-```
-RNOE_ACCOUNT_<UPPERCASE_ID>_PASSWORD=your-app-password
-```
-
-## Server Setup
-
-You need a running read-no-evil-mcp server. Three options:
-
-### Option 1: Docker (recommended)
-
-Run the interactive setup script:
-
-```bash
-scripts/setup-server.sh
-```
-
-This will:
-1. Pull the official Docker image (`ghcr.io/thekie/read-no-evil-mcp:latest`)
-2. Prompt for your config file path and email credentials
-3. Start a container on port 8000
-
-### Option 2: Existing server
-
-If you already have a server running (locally or remotely), just point the skill at it:
-
-```bash
-# Local server on default port
-rnoe-mail.py list
-
-# Remote server
-rnoe-mail.py --server http://myserver:8000 list
-
-# Or set the env var
-export RNOE_SERVER_URL=http://myserver:8000
-rnoe-mail.py list
-```
-
-### Option 3: Run the server directly
-
-See the [read-no-evil-mcp docs](https://github.com/thekie/read-no-evil-mcp) for running the server without Docker.
+Requires a running [read-no-evil-mcp](https://github.com/thekie/read-no-evil-mcp) server (Docker recommended, see server repo for setup).
 
 ## Usage
 
 ```bash
-# List accounts configured on the server
+# List configured email accounts
 rnoe-mail.py accounts
 
 # List recent emails
-rnoe-mail.py list
 rnoe-mail.py list --limit 10 --days 7
 
-# Read email (scanned for prompt injection)
+# Read an email (scanned for prompt injection!)
 rnoe-mail.py read <uid>
 
-# Send email
+# Send an email
 rnoe-mail.py send --to "user@example.com" --subject "Hello" --body "Message"
 
 # List folders
 rnoe-mail.py folders
 
-# Move email to folder
+# Move email to a folder
 rnoe-mail.py move <uid> --to "Archive"
 
-# Delete email
+# Delete an email
 rnoe-mail.py delete <uid>
 ```
 
-## Server URL Resolution
-
-The server URL is resolved in this order:
-
-1. `--server URL` CLI flag
-2. `RNOE_SERVER_URL` environment variable
-3. Default: `http://localhost:8000`
-
 ## Security
 
-- **Credential isolation**: Email passwords and server connections live only on the MCP server. The AI agent and this skill never have access to them.
-- **Prompt injection protection**: All email content is scanned by the server's ML model before being returned to the client.
-- **HTTPS warning**: The script warns if you use plain HTTP with a non-localhost server.
+All email content is scanned server-side by an ML model before reaching your agent. If a prompt injection is detected, the email is blocked and the script exits with code 2. Your email credentials never leave the server — the AI agent only sees sanitized content over HTTP.
 
 ## Credits
 
-- [read-no-evil-mcp](https://github.com/thekie/read-no-evil-mcp) — The MCP server for secure email access
+- [read-no-evil-mcp](https://github.com/thekie/read-no-evil-mcp) — The MCP server powering secure email access
 - [ProtectAI](https://protectai.com/) — Prompt injection detection model
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
 # 🦞 read-no-evil-mcp
 
-**Secure email access for your AI agent — with prompt injection protection built in.**
+> 🙈 *"Read no evil"* — Secure email access for your AI agent, with prompt injection protection built in.
 
-Your [Clawbot](https://clawhub.ai) agent can read, send, and manage emails without worrying about prompt injection attacks hiding in message content.
-
-## Features
-
-- 📧 List, read, send, move, and delete emails via a secure gateway
-- 🛡️ Automatic prompt injection detection using ML — malicious emails are flagged before your agent sees them
-- 🔒 Full credential isolation — your passwords and email connections never touch the AI agent
-- ⚙️ Configurable permissions per account (read-only, send, delete, move)
-- 🐍 Zero dependencies — pure Python stdlib, no pip install needed
+This is an [OpenClaw](https://openclaw.ai) skill published on [ClawHub](https://clawhub.ai). Your agent can read, send, and manage emails without worrying about prompt injection attacks hiding in message content.
 
 ## Install
 
@@ -18,36 +10,25 @@ Your [Clawbot](https://clawhub.ai) agent can read, send, and manage emails witho
 clawhub install read-no-evil-mcp
 ```
 
-Requires a running [read-no-evil-mcp](https://github.com/thekie/read-no-evil-mcp) server (Docker recommended, see server repo for setup).
+This skill connects to a [read-no-evil-mcp](https://github.com/thekie/read-no-evil-mcp) server. You can point it at an existing server, or let the built-in setup script spin one up locally via Docker.
 
-## Usage
+## ✨ What You Get
 
-```bash
-# List configured email accounts
-rnoe-mail.py accounts
+- 📧 **Full email management** — Your agent can read, send, move, and delete emails across multiple accounts
+- 🛡️ **Prompt injection protection** — Every email is scanned before your agent sees it. Malicious content gets blocked automatically
+- 🔒 **Your credentials stay safe** — Passwords and email connections never touch the AI. Your agent only sees clean, sanitized content
+- 🔐 **You control what your agent can do** — Read-only by default, with optional send, delete, and move permissions per account. Lock it down to specific folders if you want
+- 📬 **Sender-based rules** — Set rules for known senders. Auto-trust your team, flag external contacts for confirmation, or hide noisy newsletters
+- 🎛️ **Custom agent guidance** — Tell your agent how to handle emails from different senders. For example, act on messages from your team right away but ask you first about external contacts
+- 🎚️ **Tune the sensitivity** — Dial detection up or down per account. Tighter for your work inbox, more relaxed for newsletters
+- ✉️ **Control who your agent can email** — Restrict outgoing emails to specific people or domains
+- 📎 **Attachments included** — Your agent can send emails with file attachments
+- 👥 **Multiple accounts** — Connect as many email accounts as you need, each with its own permissions and rules
+- 🐍 **Nothing to install** — Works out of the box with no extra dependencies
 
-# List recent emails
-rnoe-mail.py list --limit 10 --days 7
+## 🔐 Security
 
-# Read an email (scanned for prompt injection!)
-rnoe-mail.py read <uid>
-
-# Send an email
-rnoe-mail.py send --to "user@example.com" --subject "Hello" --body "Message"
-
-# List folders
-rnoe-mail.py folders
-
-# Move email to a folder
-rnoe-mail.py move <uid> --to "Archive"
-
-# Delete an email
-rnoe-mail.py delete <uid>
-```
-
-## Security
-
-All email content is scanned server-side by an ML model before reaching your agent. If a prompt injection is detected, the email is blocked and the script exits with code 2. Your email credentials never leave the server — the AI agent only sees sanitized content over HTTP.
+Every email is scanned by a [DeBERTa-based ML model](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2) before reaching your agent. Scanning is never skipped, even for trusted senders. Your credentials never leave the server.
 
 ## Credits
 
@@ -57,3 +38,11 @@ All email content is scanned server-side by an ML model before reaching your age
 ## License
 
 Apache 2.0 — See [LICENSE](LICENSE)
+
+---
+
+<p align="center">
+  <b>🙈 🙉 🙊</b><br>
+  <i>See no evil. Hear no evil. Speak no evil.</i><br>
+  <i>Read no evil.</i>
+</p>

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: read-no-evil-mcp
+version: 0.3.0
 description: Secure email access via read-no-evil-mcp. Protects against prompt injection attacks in emails. Use for reading, sending, deleting, and moving emails.
 ---
 
@@ -7,62 +8,123 @@ description: Secure email access via read-no-evil-mcp. Protects against prompt i
 
 Secure email gateway that scans emails for prompt injection attacks before you see them.
 
+This skill is a zero-dependency HTTP client that talks to a [read-no-evil-mcp](https://github.com/thekie/read-no-evil-mcp) server. Credentials and email servers are managed entirely by the MCP server — this skill never has direct access to them.
+
 ## Prerequisites
 
-Install the read-no-evil-mcp package (version must match skill version):
+A running read-no-evil-mcp server with HTTP transport enabled. Three connection modes:
+
+1. **Remote server** — An existing server on another machine. You need the URL (e.g. `http://server:8000`).
+2. **Local server** — An existing server on localhost. Uses default `http://localhost:8000`.
+3. **New Docker setup** — Use `scripts/setup-server.sh` to pull the official Docker image and start a container.
+
+No `pip install` is required. The script uses only Python stdlib.
+
+## Setup Flow (AI Agent Instructions)
+
+**Before first use, always ask the user how they want to connect:**
+
+> How would you like to connect to the read-no-evil-mcp server?
+> 1. Connect to an existing remote server (you'll provide the URL)
+> 2. Connect to an existing local server (localhost:8000)
+> 3. Set up a new local server via Docker
+
+- For option 1: Ask for the server URL, then use `--server URL` with all commands.
+- For option 2: No extra configuration needed, commands use the default URL.
+- For option 3: Follow the Docker setup steps below.
+
+**Never auto-setup Docker without explicit user confirmation.**
+
+### Docker Setup Steps
+
+1. Check if a config exists: `setup-config.py list`
+2. If no config, create one and add an account:
+   ```bash
+   setup-config.py create
+   setup-config.py add --email user@gmail.com --send --create-env
+   ```
+3. Ask the user to fill in the password in the `.env` file.
+4. Start the server:
+   ```bash
+   scripts/setup-server.sh --config ~/.config/read-no-evil-mcp/config.yaml \
+     --env-file ~/.config/read-no-evil-mcp/.env
+   ```
+
+### Config Management (AI Agent Instructions)
+
+Use `scripts/setup-config.py` to manage the server config file. All commands are flag-driven with no interactive prompts.
+
+| Scenario | Command |
+|----------|---------|
+| Create config skeleton | `setup-config.py create [--threshold 0.5] [--force]` |
+| Add an email account | `setup-config.py add --email user@gmail.com [--id gmail] [--send] [--delete] [--move] [--create-env]` |
+| Check what accounts are configured | `setup-config.py list` |
+| Remove an account | `setup-config.py remove <id>` |
+
+**Do NOT** run `setup-config.py show` — it displays config details the user may not intend to share with the agent. If debugging is needed, tell the user to run it themselves.
+
+**Do NOT** run `setup-config.py create --force` if config already exists without asking the user first.
+
+## Config Commands
+
+Manage the server config file (`~/.config/read-no-evil-mcp/config.yaml`). No pip install required — stdlib only.
 
 ```bash
-pip install read-no-evil-mcp==0.2.0
+# Create a new config skeleton
+setup-config.py create
+setup-config.py create --threshold 0.3 --force
+
+# Add an account (provider auto-detected from email domain)
+setup-config.py add --email user@gmail.com --send --create-env
+setup-config.py add --email user@gmail.com --id gmail --send --delete --move
+
+# Add a generic IMAP account
+setup-config.py add --email user@example.com --provider generic \
+  --imap-host imap.example.com --smtp-host smtp.example.com --send
+
+# Remove an account
+setup-config.py remove <account-id>
+
+# List configured accounts
+setup-config.py list
+
+# Show full config file
+setup-config.py show
+
+# Use a custom config path
+setup-config.py --config /path/to/config.yaml create
 ```
 
-## Configuration
+Provider presets are included for Gmail, Outlook, and Yahoo. The provider is auto-detected from the email domain and IMAP/SMTP settings are pre-filled.
 
-### Config File
-
-Create `~/.config/read-no-evil-mcp/config.yaml`:
-
-```yaml
-accounts:
-  - id: "default"
-    type: "imap"
-    host: "mail.example.com"
-    port: 993
-    username: "you@example.com"
-    ssl: true
-    permissions:
-      read: true
-      send: false
-      delete: false
-      move: false
-    smtp_host: "mail.example.com"
-    smtp_port: 587
-    from_address: "you@example.com"
-    from_name: "Your Name"
-```
-
-### Credentials
-
-Create `~/.config/read-no-evil-mcp/.env`:
+## Server Setup
 
 ```bash
-RNOE_ACCOUNT_DEFAULT_PASSWORD=your-password
-```
+# Start a Docker container (all flags required, no prompts)
+scripts/setup-server.sh --config ~/.config/read-no-evil-mcp/config.yaml \
+  --env-file ~/.config/read-no-evil-mcp/.env
 
-Environment variable format: `RNOE_ACCOUNT_{ACCOUNT_ID}_PASSWORD` (uppercase).
+# Custom port and container name
+scripts/setup-server.sh --config /path/to/config.yaml \
+  --env-file /path/to/.env --port 9000 --name my-rnoe
+```
 
 ## CLI Commands
 
+All commands accept `--server URL` to specify the MCP server (default: `http://localhost:8000`). Can also be set via `RNOE_SERVER_URL` env var.
+
 ```bash
+# List configured accounts
+rnoe-mail.py accounts
+
 # List recent emails (last 30 days)
 rnoe-mail.py list
-
-# List with options
 rnoe-mail.py list --limit 10 --days 7 --account myaccount
 
 # Read email (scanned for prompt injection!)
 rnoe-mail.py read <uid>
 
-# Send email (requires send permission)
+# Send email
 rnoe-mail.py send --to "user@example.com" --subject "Hello" --body "Message"
 
 # List folders
@@ -70,29 +132,38 @@ rnoe-mail.py folders
 
 # Move email to folder
 rnoe-mail.py move <uid> --to "Archive"
+
+# Delete email
+rnoe-mail.py delete <uid>
+
+# Use a specific server
+rnoe-mail.py --server http://myserver:8000 list
 ```
+
+## Common Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--server URL` | MCP server URL | `http://localhost:8000` |
+| `--account ID` / `-a` | Account ID | `default` |
+| `--folder NAME` / `-f` | Email folder | `INBOX` |
 
 ## Prompt Injection Detection
 
-All emails are automatically scanned:
+All emails are automatically scanned by the MCP server:
 
 - **Safe**: Content displayed normally
-- **Injection detected**: Exit code 2, shows score + patterns
+- **Injection detected**: Exit code 2, warning on stderr
 
-Uses ProtectAI's DeBERTa model (local inference, no external APIs).
+## Exit Codes
 
-## Permissions
-
-| Permission | Description | Default |
-|------------|-------------|---------|
-| `read` | List and read emails | `true` |
-| `send` | Send emails via SMTP | `false` |
-| `delete` | Delete emails | `false` |
-| `move` | Move emails between folders | `false` |
+- `0` — success
+- `1` — general error (connection failed, invalid account, etc.)
+- `2` — prompt injection detected
 
 ## Security Notes
 
-- Emails are scanned for prompt injection before content is returned
-- ML model runs locally — no data sent to external APIs
-- Enable write permissions only when needed
-- Consider using app-specific passwords
+- Credentials are managed by the MCP server, never by this skill or the AI agent
+- The skill communicates with the server over HTTP — use HTTPS for non-localhost connections
+- The script warns on stderr if using plain HTTP with a non-localhost server
+- Prompt injection scanning happens server-side using ML models

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,7 +41,7 @@ No `pip install` is required. The script uses only Python stdlib.
 2. If no config, create one and add an account:
    ```bash
    setup-config.py create
-   setup-config.py add --email user@example.com --host imap.example.com --smtp-host smtp.example.com --send --create-env
+   setup-config.py add --email user@example.com --host imap.example.com --create-env
    ```
 3. Ask the user to fill in the password in the `.env` file.
 4. Start the server:
@@ -57,7 +57,8 @@ Use `scripts/setup-config.py` to manage the server config file. All commands are
 | Scenario | Command |
 |----------|---------|
 | Create config skeleton | `setup-config.py create [--threshold 0.5] [--force]` |
-| Add an email account | `setup-config.py add --email user@example.com --host imap.example.com --smtp-host smtp.example.com [--id myaccount] [--send] [--delete] [--move] [--create-env]` |
+| Add a read-only account | `setup-config.py add --email user@example.com --host imap.example.com [--id myaccount] [--create-env]` |
+| Add a send-enabled account | `setup-config.py add --email user@example.com --host imap.example.com --smtp-host smtp.example.com --send [--delete] [--move] [--create-env]` |
 | Check what accounts are configured | `setup-config.py list` |
 | Remove an account | `setup-config.py remove <id>` |
 
@@ -74,9 +75,10 @@ Manage the server config file (`~/.config/read-no-evil-mcp/config.yaml`). No pip
 setup-config.py create
 setup-config.py create --threshold 0.3 --force
 
-# Add an account (--host and --smtp-host are required)
-setup-config.py add --email user@example.com \
-  --host imap.example.com --smtp-host smtp.example.com --send --create-env
+# Add a read-only account (no SMTP needed)
+setup-config.py add --email user@example.com --host imap.example.com --create-env
+
+# Add an account with send permission (--smtp-host required for --send)
 setup-config.py add --email user@example.com --id myaccount \
   --host imap.example.com --smtp-host smtp.example.com --send --delete --move
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,7 +41,7 @@ No `pip install` is required. The script uses only Python stdlib.
 2. If no config, create one and add an account:
    ```bash
    setup-config.py create
-   setup-config.py add --email user@gmail.com --send --create-env
+   setup-config.py add --email user@example.com --host imap.example.com --smtp-host smtp.example.com --send --create-env
    ```
 3. Ask the user to fill in the password in the `.env` file.
 4. Start the server:
@@ -57,7 +57,7 @@ Use `scripts/setup-config.py` to manage the server config file. All commands are
 | Scenario | Command |
 |----------|---------|
 | Create config skeleton | `setup-config.py create [--threshold 0.5] [--force]` |
-| Add an email account | `setup-config.py add --email user@gmail.com [--id gmail] [--send] [--delete] [--move] [--create-env]` |
+| Add an email account | `setup-config.py add --email user@example.com --host imap.example.com --smtp-host smtp.example.com [--id myaccount] [--send] [--delete] [--move] [--create-env]` |
 | Check what accounts are configured | `setup-config.py list` |
 | Remove an account | `setup-config.py remove <id>` |
 
@@ -74,13 +74,11 @@ Manage the server config file (`~/.config/read-no-evil-mcp/config.yaml`). No pip
 setup-config.py create
 setup-config.py create --threshold 0.3 --force
 
-# Add an account (provider auto-detected from email domain)
-setup-config.py add --email user@gmail.com --send --create-env
-setup-config.py add --email user@gmail.com --id gmail --send --delete --move
-
-# Add a generic IMAP account
-setup-config.py add --email user@example.com --provider generic \
-  --imap-host imap.example.com --smtp-host smtp.example.com --send
+# Add an account (--host and --smtp-host are required)
+setup-config.py add --email user@example.com \
+  --host imap.example.com --smtp-host smtp.example.com --send --create-env
+setup-config.py add --email user@example.com --id myaccount \
+  --host imap.example.com --smtp-host smtp.example.com --send --delete --move
 
 # Remove an account
 setup-config.py remove <account-id>
@@ -94,8 +92,6 @@ setup-config.py show
 # Use a custom config path
 setup-config.py --config /path/to/config.yaml create
 ```
-
-Provider presets are included for Gmail, Outlook, and Yahoo. The provider is auto-detected from the email domain and IMAP/SMTP settings are pre-filled.
 
 ## Server Setup
 
@@ -165,5 +161,4 @@ All emails are automatically scanned by the MCP server:
 
 - Credentials are managed by the MCP server, never by this skill or the AI agent
 - The skill communicates with the server over HTTP — use HTTPS for non-localhost connections
-- The script warns on stderr if using plain HTTP with a non-localhost server
 - Prompt injection scanning happens server-side using ML models

--- a/scripts/rnoe-mail.py
+++ b/scripts/rnoe-mail.py
@@ -116,7 +116,6 @@ class McpClient:
         }
         resp, _ = self._post(req)
 
-        # Handle JSON-RPC error
         if "error" in resp:
             err = resp["error"]
             return err.get("message", str(err)), True
@@ -240,21 +239,6 @@ def resolve_server_url(args):
     return "http://localhost:8000"
 
 
-def warn_non_localhost_http(url):
-    """Warn if using plain HTTP with a non-localhost server."""
-    if not url.startswith("http://"):
-        return
-    from urllib.parse import urlparse
-    parsed = urlparse(url)
-    host = parsed.hostname or ""
-    if host not in ("localhost", "127.0.0.1", "::1", "[::1]"):
-        print(
-            f"Warning: Using unencrypted HTTP with non-localhost server ({host}). "
-            "Consider using HTTPS.",
-            file=sys.stderr,
-        )
-
-
 def main():
     parser = argparse.ArgumentParser(
         description="Secure email access via MCP server with prompt injection protection"
@@ -299,7 +283,6 @@ def main():
     args = parser.parse_args()
 
     server_url = resolve_server_url(args)
-    warn_non_localhost_http(server_url)
 
     client = McpClient(server_url)
     try:

--- a/scripts/rnoe-mail.py
+++ b/scripts/rnoe-mail.py
@@ -1,271 +1,336 @@
 #!/usr/bin/env python3
 """
-CLI wrapper for read-no-evil-mcp secure email access.
-Provides prompt injection protection for email reading.
+MCP HTTP client for read-no-evil-mcp secure email access.
+Speaks the MCP Streamable HTTP protocol to a remote server.
+
+Zero dependencies — uses only Python stdlib (3.8+).
 
 Usage:
+    rnoe-mail.py accounts
     rnoe-mail.py list [--limit N] [--days N]
     rnoe-mail.py read <uid>
     rnoe-mail.py send --to ADDR --subject SUBJ --body BODY [--cc ADDR]
     rnoe-mail.py folders
     rnoe-mail.py move <uid> --to FOLDER
+    rnoe-mail.py delete <uid>
 """
 
 import argparse
+import json
 import os
 import sys
-from datetime import timedelta
-from pathlib import Path
-
-import yaml
-from pydantic import SecretStr
-
-import read_no_evil_mcp as rnoe
-from read_no_evil_mcp.accounts.permissions import AccountPermissions
+import urllib.error
+import urllib.request
 
 
-def load_config():
-    """Load config from ~/.config/read-no-evil-mcp/config.yaml"""
-    config_path = Path.home() / ".config" / "read-no-evil-mcp" / "config.yaml"
-    if not config_path.exists():
-        raise FileNotFoundError(f"Config not found: {config_path}")
-    
-    with open(config_path) as f:
-        return yaml.safe_load(f)
+class McpClient:
+    """Minimal MCP Streamable HTTP client using only stdlib."""
 
+    def __init__(self, server_url):
+        self.server_url = server_url.rstrip("/")
+        self.endpoint = self.server_url + "/mcp"
+        self.session_id = None
+        self._id_counter = 0
 
-def get_password(account_id: str) -> str:
-    """Get password from environment variable."""
-    env_key = f"RNOE_ACCOUNT_{account_id.upper()}_PASSWORD"
-    password = os.environ.get(env_key)
-    if not password:
-        # Try loading from .env file
-        env_file = Path.home() / ".config" / "read-no-evil-mcp" / ".env"
-        if env_file.exists():
-            with open(env_file) as f:
-                for line in f:
-                    line = line.strip()
-                    if line.startswith(f"{env_key}="):
-                        password = line.split("=", 1)[1].strip('"\'')
-                        break
-    if not password:
-        raise ValueError(f"Password not found. Set {env_key} or add to .env")
-    return password
+    def _next_id(self):
+        self._id_counter += 1
+        return self._id_counter
 
-
-def create_mailbox(account_config: dict) -> rnoe.SecureMailbox:
-    """Create a SecureMailbox from account config."""
-    account_id = account_config["id"]
-    password = get_password(account_id)
-    
-    # Create IMAP config
-    imap_config = rnoe.IMAPConfig(
-        host=account_config["host"],
-        port=account_config["port"],
-        username=account_config["username"],
-        password=SecretStr(password),
-        ssl=account_config.get("ssl", True),
-    )
-    
-    # Create SMTP config if available
-    smtp_config = None
-    if "smtp_host" in account_config:
-        from read_no_evil_mcp.models import SMTPConfig
-        smtp_config = SMTPConfig(
-            host=account_config["smtp_host"],
-            port=account_config.get("smtp_port", 587),
-            username=account_config["username"],
-            password=SecretStr(password),
-            ssl=account_config.get("smtp_ssl", False),
+    def _post(self, payload):
+        """POST JSON to the MCP endpoint. Returns (parsed_body, headers)."""
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            self.endpoint,
+            data=data,
+            headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
         )
-    
-    # Create connector
-    connector = rnoe.IMAPConnector(imap_config, smtp_config)
-    
-    # Create permissions
-    perms = account_config.get("permissions", {})
-    permissions = AccountPermissions(
-        read=perms.get("read", True),
-        delete=perms.get("delete", False),
-        send=perms.get("send", False),
-        move=perms.get("move", False),
-    )
-    
-    # Create protection service with scanner
-    protection = rnoe.ProtectionService(scanner=rnoe.HeuristicScanner())
-    
-    # Create secure mailbox
-    return rnoe.SecureMailbox(
-        connector=connector,
-        permissions=permissions,
-        protection=protection,
-        from_address=account_config.get("from_address"),
-        from_name=account_config.get("from_name"),
-    )
+        if self.session_id:
+            req.add_header("Mcp-Session-Id", self.session_id)
+
+        try:
+            resp = urllib.request.urlopen(req)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"HTTP {e.code}: {body}")
+        except urllib.error.URLError as e:
+            raise ConnectionError(f"Cannot connect to {self.server_url}: {e.reason}")
+
+        headers = resp.headers
+        content_type = headers.get("Content-Type", "")
+        raw = resp.read().decode("utf-8")
+
+        if "text/event-stream" in content_type:
+            parsed = self._parse_sse(raw)
+        else:
+            parsed = json.loads(raw) if raw.strip() else {}
+
+        return parsed, headers
+
+    @staticmethod
+    def _parse_sse(raw):
+        """Parse SSE stream, return the last JSON-RPC message with a result or error."""
+        last_message = None
+        for line in raw.splitlines():
+            if line.startswith("data:"):
+                payload = line[len("data:"):].strip()
+                if payload:
+                    try:
+                        msg = json.loads(payload)
+                        if "result" in msg or "error" in msg:
+                            last_message = msg
+                    except json.JSONDecodeError:
+                        continue
+        return last_message or {}
+
+    def initialize(self):
+        """Send MCP initialize + initialized notification."""
+        init_req = {
+            "jsonrpc": "2.0",
+            "id": self._next_id(),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "rnoe-mail", "version": "0.3.0"},
+            },
+        }
+        resp, headers = self._post(init_req)
+        sid = headers.get("Mcp-Session-Id")
+        if sid:
+            self.session_id = sid
+
+        # Send initialized notification (no id = notification)
+        notif = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        try:
+            self._post(notif)
+        except Exception:
+            pass  # Notifications may return empty or 204
+
+    def call_tool(self, name, arguments=None):
+        """Call an MCP tool. Returns (text, is_error)."""
+        req = {
+            "jsonrpc": "2.0",
+            "id": self._next_id(),
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        }
+        resp, _ = self._post(req)
+
+        # Handle JSON-RPC error
+        if "error" in resp:
+            err = resp["error"]
+            return err.get("message", str(err)), True
+
+        result = resp.get("result", {})
+        is_error = result.get("isError", False)
+
+        # Extract text from content array
+        content = result.get("content", [])
+        texts = []
+        for item in content:
+            if item.get("type") == "text":
+                texts.append(item.get("text", ""))
+        text = "\n".join(texts) if texts else ""
+        return text, is_error
+
+    def close(self):
+        """No persistent connection to close with HTTP transport."""
+        pass
 
 
-def cmd_list(mailbox: rnoe.SecureMailbox, args):
-    """List emails in inbox."""
-    mailbox.connect()
-    try:
-        emails = mailbox.fetch_emails(
-            folder=args.folder or "INBOX",
-            lookback=timedelta(days=args.days),
-            limit=args.limit,
-        )
-        
-        for email_summary in emails:
-            att = "📎" if email_summary.has_attachments else "  "
-            from_addr = str(email_summary.sender) if email_summary.sender else "(unknown)"
-            subject = email_summary.subject or "(no subject)"
-            date = email_summary.date.strftime("%Y-%m-%d %H:%M") if email_summary.date else ""
-            print(f"{att} {email_summary.uid:>4} | {from_addr[:40]:<40} | {subject[:45]:<45} | {date}")
-    finally:
-        mailbox.disconnect()
+def detect_prompt_injection(text):
+    """Check if server response indicates a blocked prompt injection."""
+    if not text:
+        return False
+    lower = text.lower()
+    return "blocked:" in lower and "prompt injection" in lower
 
 
-def cmd_read(mailbox: rnoe.SecureMailbox, args):
-    """Read a specific email with prompt injection scanning."""
-    mailbox.connect()
-    try:
-        email_obj = mailbox.get_email(
-            folder=args.folder or "INBOX",
-            uid=args.uid,
-        )
-        
-        if not email_obj:
-            print(f"Email with UID {args.uid} not found", file=sys.stderr)
-            sys.exit(1)
-        
-        print(f"From: {email_obj.sender}")
-        print(f"To: {', '.join(str(r) for r in (email_obj.recipients or []))}")
-        print(f"Date: {email_obj.date}")
-        print(f"Subject: {email_obj.subject}")
-        
-        if email_obj.attachments:
-            print(f"\nAttachments: {len(email_obj.attachments)}")
-            for att in email_obj.attachments:
-                print(f"  📎 {att.filename} ({att.content_type})")
-        
-        print("\n--- Body ---")
-        print(email_obj.body or "(empty)")
-        
-    except rnoe.PromptInjectionError as e:
-        print(f"⚠️  PROMPT INJECTION DETECTED!", file=sys.stderr)
-        print(f"Score: {e.scan_result.score:.2f}", file=sys.stderr)
-        if e.scan_result.detected_patterns:
-            print(f"Patterns: {e.scan_result.detected_patterns}", file=sys.stderr)
+def cmd_accounts(client, _args):
+    text, is_error = client.call_tool("list_accounts")
+    if is_error:
+        print(text, file=sys.stderr)
+        sys.exit(1)
+    print(text)
+
+
+def cmd_list(client, args):
+    arguments = {"account": args.account, "folder": args.folder}
+    if args.limit:
+        arguments["limit"] = args.limit
+    if args.days:
+        arguments["days_back"] = args.days
+    text, is_error = client.call_tool("list_emails", arguments)
+    if is_error:
+        print(text, file=sys.stderr)
+        sys.exit(1)
+    print(text)
+
+
+def cmd_read(client, args):
+    arguments = {"account": args.account, "folder": args.folder, "uid": args.uid}
+    text, is_error = client.call_tool("get_email", arguments)
+    if is_error:
+        if detect_prompt_injection(text):
+            print(text, file=sys.stderr)
+            sys.exit(2)
+        print(text, file=sys.stderr)
+        sys.exit(1)
+    if detect_prompt_injection(text):
+        print(text, file=sys.stderr)
         sys.exit(2)
-    finally:
-        mailbox.disconnect()
+    print(text)
 
 
-def cmd_send(mailbox: rnoe.SecureMailbox, args):
-    """Send an email."""
-    mailbox.connect()
-    try:
-        cc = args.cc.split(",") if args.cc else None
-        
-        mailbox.send_email(
-            to=args.to.split(","),
-            subject=args.subject,
-            body=args.body,
-            cc=cc,
+def cmd_send(client, args):
+    arguments = {
+        "account": args.account,
+        "to": args.to,
+        "subject": args.subject,
+        "body": args.body,
+    }
+    if args.cc:
+        arguments["cc"] = args.cc
+    text, is_error = client.call_tool("send_email", arguments)
+    if is_error:
+        print(text, file=sys.stderr)
+        sys.exit(1)
+    print(text)
+
+
+def cmd_folders(client, args):
+    arguments = {"account": args.account}
+    text, is_error = client.call_tool("list_folders", arguments)
+    if is_error:
+        print(text, file=sys.stderr)
+        sys.exit(1)
+    print(text)
+
+
+def cmd_move(client, args):
+    arguments = {
+        "account": args.account,
+        "folder": args.folder,
+        "uid": args.uid,
+        "target_folder": args.to,
+    }
+    text, is_error = client.call_tool("move_email", arguments)
+    if is_error:
+        print(text, file=sys.stderr)
+        sys.exit(1)
+    print(text)
+
+
+def cmd_delete(client, args):
+    arguments = {"account": args.account, "folder": args.folder, "uid": args.uid}
+    text, is_error = client.call_tool("delete_email", arguments)
+    if is_error:
+        print(text, file=sys.stderr)
+        sys.exit(1)
+    print(text)
+
+
+def resolve_server_url(args):
+    """Resolve server URL from CLI flag, env var, or default."""
+    if args.server:
+        return args.server
+    url = os.environ.get("RNOE_SERVER_URL")
+    if url:
+        return url
+    return "http://localhost:8000"
+
+
+def warn_non_localhost_http(url):
+    """Warn if using plain HTTP with a non-localhost server."""
+    if not url.startswith("http://"):
+        return
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if host not in ("localhost", "127.0.0.1", "::1", "[::1]"):
+        print(
+            f"Warning: Using unencrypted HTTP with non-localhost server ({host}). "
+            "Consider using HTTPS.",
+            file=sys.stderr,
         )
-        print(f"✅ Email sent to {args.to}")
-    finally:
-        mailbox.disconnect()
-
-
-def cmd_folders(mailbox: rnoe.SecureMailbox, args):
-    """List available folders."""
-    mailbox.connect()
-    try:
-        folders = mailbox.list_folders()
-        for folder in folders:
-            print(f"📁 {folder.name}")
-    finally:
-        mailbox.disconnect()
-
-
-def cmd_move(mailbox: rnoe.SecureMailbox, args):
-    """Move email to another folder."""
-    mailbox.connect()
-    try:
-        mailbox.move_email(
-            folder=args.folder or "INBOX",
-            uid=args.uid,
-            target_folder=args.to,
-        )
-        print(f"✅ Email {args.uid} moved to {args.to}")
-    finally:
-        mailbox.disconnect()
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Secure email access with prompt injection protection")
+    parser = argparse.ArgumentParser(
+        description="Secure email access via MCP server with prompt injection protection"
+    )
+    parser.add_argument("--server", help="MCP server URL (default: http://localhost:8000)")
     parser.add_argument("--account", "-a", default="default", help="Account ID (default: default)")
     parser.add_argument("--folder", "-f", default="INBOX", help="Folder (default: INBOX)")
-    
+
     subparsers = parser.add_subparsers(dest="command", required=True)
-    
+
+    # accounts
+    subparsers.add_parser("accounts", help="List configured accounts")
+
     # list
     list_parser = subparsers.add_parser("list", help="List emails")
-    list_parser.add_argument("--limit", "-n", type=int, default=20, help="Max emails to list")
+    list_parser.add_argument("--limit", "-n", type=int, default=20, help="Max emails (default: 20)")
     list_parser.add_argument("--days", "-d", type=int, default=30, help="Lookback days (default: 30)")
-    
+
     # read
     read_parser = subparsers.add_parser("read", help="Read an email")
     read_parser.add_argument("uid", type=int, help="Email UID")
-    
+
     # send
     send_parser = subparsers.add_parser("send", help="Send an email")
     send_parser.add_argument("--to", required=True, help="Recipient(s), comma-separated")
     send_parser.add_argument("--subject", "-s", required=True, help="Subject")
     send_parser.add_argument("--body", "-b", required=True, help="Body text")
     send_parser.add_argument("--cc", help="CC recipient(s), comma-separated")
-    
+
     # folders
     subparsers.add_parser("folders", help="List folders")
-    
+
     # move
     move_parser = subparsers.add_parser("move", help="Move email to folder")
     move_parser.add_argument("uid", type=int, help="Email UID")
     move_parser.add_argument("--to", required=True, help="Target folder")
-    
+
+    # delete
+    delete_parser = subparsers.add_parser("delete", help="Delete an email")
+    delete_parser.add_argument("uid", type=int, help="Email UID")
+
     args = parser.parse_args()
-    
-    # Load config and create mailbox
-    config = load_config()
-    account_config = None
-    for acc in config.get("accounts", []):
-        if acc["id"] == args.account:
-            account_config = acc
-            break
-    
-    if not account_config:
-        print(f"Account '{args.account}' not found in config", file=sys.stderr)
+
+    server_url = resolve_server_url(args)
+    warn_non_localhost_http(server_url)
+
+    client = McpClient(server_url)
+    try:
+        client.initialize()
+    except ConnectionError as e:
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-    
-    mailbox = create_mailbox(account_config)
-    
-    # Dispatch command
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
     commands = {
+        "accounts": cmd_accounts,
         "list": cmd_list,
         "read": cmd_read,
         "send": cmd_send,
         "folders": cmd_folders,
         "move": cmd_move,
+        "delete": cmd_delete,
     }
-    
+
     try:
-        commands[args.command](mailbox, args)
-    except rnoe.PromptInjectionError as e:
-        print(f"⚠️  PROMPT INJECTION DETECTED!", file=sys.stderr)
-        sys.exit(2)
-    except Exception as e:
+        commands[args.command](client, args)
+    except ConnectionError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        client.close()
 
 
 if __name__ == "__main__":

--- a/scripts/setup-config.py
+++ b/scripts/setup-config.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""
+Flag-driven configuration manager for read-no-evil-mcp.
+
+Creates and manages config.yaml files for the read-no-evil-mcp server.
+Zero dependencies — uses only Python stdlib (3.8+).
+Designed for invocation by LLM agents (no interactive prompts).
+
+Usage:
+    setup-config.py create [--threshold 0.5] [--force]
+    setup-config.py add --email USER@DOMAIN [--id ID] [--provider PROVIDER] ...
+    setup-config.py remove <account_id>
+    setup-config.py list
+    setup-config.py show
+"""
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+
+
+# --- Constants ---
+
+DEFAULT_CONFIG = os.path.join(
+    os.environ.get("XDG_CONFIG_HOME", os.path.join(os.path.expanduser("~"), ".config")),
+    "read-no-evil-mcp",
+    "config.yaml",
+)
+
+PROVIDERS = {
+    "gmail": {
+        "label": "Gmail",
+        "host": "imap.gmail.com",
+        "port": 993,
+        "ssl": True,
+        "smtp_host": "smtp.gmail.com",
+        "smtp_port": 587,
+        "smtp_ssl": False,
+        "sent_folder": "[Gmail]/Sent Mail",
+    },
+    "outlook": {
+        "label": "Outlook / Hotmail",
+        "host": "imap-mail.outlook.com",
+        "port": 993,
+        "ssl": True,
+        "smtp_host": "smtp-mail.outlook.com",
+        "smtp_port": 587,
+        "smtp_ssl": False,
+    },
+    "yahoo": {
+        "label": "Yahoo Mail",
+        "host": "imap.mail.yahoo.com",
+        "port": 993,
+        "ssl": True,
+        "smtp_host": "smtp.mail.yahoo.com",
+        "smtp_port": 587,
+        "smtp_ssl": False,
+    },
+    "generic": {
+        "label": "Generic IMAP (provide host details via flags)",
+    },
+}
+
+# Domain to provider key mapping
+DOMAIN_PROVIDERS = {
+    "gmail.com": "gmail",
+    "googlemail.com": "gmail",
+    "outlook.com": "outlook",
+    "hotmail.com": "outlook",
+    "live.com": "outlook",
+    "yahoo.com": "yahoo",
+    "ymail.com": "yahoo",
+}
+
+ACCOUNT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+# --- YAML serializer ---
+
+def dump_yaml(config):
+    """Serialize config dict to YAML string."""
+    lines = []
+    _dump_dict(lines, config, indent=0)
+    return "\n".join(lines) + "\n"
+
+
+def _dump_dict(lines, d, indent):
+    prefix = "  " * indent
+    for key, val in d.items():
+        if isinstance(val, dict):
+            lines.append(f"{prefix}{key}:")
+            _dump_dict(lines, val, indent + 1)
+        elif isinstance(val, list):
+            lines.append(f"{prefix}{key}:")
+            _dump_list(lines, val, indent + 1)
+        else:
+            lines.append(f"{prefix}{key}: {_format_scalar(val)}")
+
+
+def _dump_list(lines, lst, indent):
+    prefix = "  " * indent
+    for item in lst:
+        if isinstance(item, dict):
+            keys = list(item.items())
+            first_key, first_val = keys[0]
+            if isinstance(first_val, (dict, list)):
+                lines.append(f"{prefix}- {first_key}:")
+                if isinstance(first_val, dict):
+                    _dump_dict(lines, first_val, indent + 2)
+                else:
+                    _dump_list(lines, first_val, indent + 2)
+            else:
+                lines.append(f"{prefix}- {first_key}: {_format_scalar(first_val)}")
+            for key, val in keys[1:]:
+                if isinstance(val, dict):
+                    lines.append(f"{prefix}  {key}:")
+                    _dump_dict(lines, val, indent + 2)
+                elif isinstance(val, list):
+                    lines.append(f"{prefix}  {key}:")
+                    _dump_list(lines, val, indent + 2)
+                else:
+                    lines.append(f"{prefix}  {key}: {_format_scalar(val)}")
+        else:
+            lines.append(f"{prefix}- {_format_scalar(item)}")
+
+
+def _format_scalar(val):
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    if isinstance(val, int):
+        return str(val)
+    if isinstance(val, float):
+        return str(val)
+    if isinstance(val, str):
+        return _quote_string(val)
+    if val is None:
+        return "null"
+    return str(val)
+
+
+def _quote_string(s):
+    """Quote strings that need it, leave simple ones bare."""
+    if not s:
+        return '""'
+    needs_quote = False
+    if s.strip() != s:
+        needs_quote = True
+    if s.lower() in ("true", "false", "null", "yes", "no", "on", "off"):
+        needs_quote = True
+    special = set(":#{}[]!&*?,|>'\"@`")
+    if any(c in special for c in s):
+        needs_quote = True
+    try:
+        float(s)
+        needs_quote = True
+    except ValueError:
+        pass
+    if needs_quote:
+        escaped = s.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return s
+
+
+# --- YAML parser ---
+
+def load_yaml(text):
+    """Parse YAML text (as produced by dump_yaml) into a dict."""
+    lines = _prepare_lines(text)
+    if not lines:
+        return {}
+    result, _ = _parse_block(lines, 0, 0)
+    return result if isinstance(result, dict) else {}
+
+
+def _prepare_lines(text):
+    """Strip comments and blank lines, return list of (indent, content) tuples."""
+    result = []
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip())
+        result.append((indent, stripped))
+    return result
+
+
+def _parse_block(lines, pos, base_indent):
+    """Parse a block at a given indent level. Returns (value, next_pos)."""
+    if pos >= len(lines):
+        return {}, pos
+
+    indent, content = lines[pos]
+
+    # Determine if this is a list or dict block
+    if content.startswith("- "):
+        return _parse_list_block(lines, pos, base_indent)
+    else:
+        return _parse_dict_block(lines, pos, base_indent)
+
+
+def _parse_dict_block(lines, pos, base_indent):
+    """Parse a dict block."""
+    result = {}
+    while pos < len(lines):
+        indent, content = lines[pos]
+        if indent < base_indent:
+            break
+        if indent > base_indent:
+            break
+        if content.startswith("- "):
+            break
+
+        key, val_str = _split_key_value(content)
+        if val_str is not None:
+            result[key] = _parse_scalar(val_str)
+            pos += 1
+        else:
+            # Block value — peek at next line to determine type
+            if pos + 1 < len(lines) and lines[pos + 1][0] > indent:
+                child, pos = _parse_block(lines, pos + 1, lines[pos + 1][0])
+                result[key] = child
+            else:
+                result[key] = None
+                pos += 1
+    return result, pos
+
+
+def _parse_list_block(lines, pos, base_indent):
+    """Parse a list block."""
+    result = []
+    while pos < len(lines):
+        indent, content = lines[pos]
+        if indent < base_indent:
+            break
+        if indent > base_indent:
+            break
+        if not content.startswith("- "):
+            break
+
+        item_content = content[2:]
+        key, val_str = _split_key_value(item_content)
+
+        if key is not None and val_str is not None:
+            # - key: value — start of a dict item
+            item = {key: _parse_scalar(val_str)}
+            pos += 1
+            # Collect remaining keys at indent + 2
+            child_indent = base_indent + 2
+            while pos < len(lines) and lines[pos][0] >= child_indent:
+                if lines[pos][0] > child_indent and not lines[pos][1].startswith("- "):
+                    break
+                if lines[pos][0] < child_indent:
+                    break
+                ci, cc = lines[pos]
+                if cc.startswith("- "):
+                    break
+                k2, v2 = _split_key_value(cc)
+                if k2 is not None and v2 is not None:
+                    item[k2] = _parse_scalar(v2)
+                    pos += 1
+                elif k2 is not None:
+                    # Nested block
+                    if pos + 1 < len(lines) and lines[pos + 1][0] > ci:
+                        child, pos = _parse_block(lines, pos + 1, lines[pos + 1][0])
+                        item[k2] = child
+                    else:
+                        item[k2] = None
+                        pos += 1
+                else:
+                    break
+            result.append(item)
+        elif key is not None and val_str is None:
+            # - key:  (block value follows)
+            if pos + 1 < len(lines) and lines[pos + 1][0] > base_indent:
+                child, pos_next = _parse_block(lines, pos + 1, lines[pos + 1][0])
+                result.append({key: child})
+                pos = pos_next
+            else:
+                result.append({key: None})
+                pos += 1
+        else:
+            # - scalar
+            result.append(_parse_scalar(item_content))
+            pos += 1
+    return result, pos
+
+
+def _split_key_value(content):
+    """Split 'key: value' or 'key:' line. Returns (key, value_str) or (key, None) or (None, None)."""
+    # Handle quoted keys (unlikely in our format but be safe)
+    if content.startswith('"'):
+        end = content.find('"', 1)
+        if end == -1:
+            return None, None
+        key = content[1:end]
+        rest = content[end + 1:]
+        if rest.startswith(":"):
+            val = rest[1:].strip()
+            return key, val if val else None
+        return None, None
+
+    colon_pos = content.find(":")
+    if colon_pos == -1:
+        return None, None
+
+    key = content[:colon_pos]
+    rest = content[colon_pos + 1:]
+
+    if not rest:
+        return key, None
+    if rest[0] == " ":
+        val = rest[1:].strip() if len(rest) > 1 else ""
+        return key, val if val else None
+    # Colon in the middle of a word, not a key separator
+    return None, None
+
+
+def _parse_scalar(s):
+    """Parse a scalar string into a Python value."""
+    s = s.strip()
+    if not s:
+        return ""
+
+    # Quoted string
+    if (s.startswith('"') and s.endswith('"')) or (s.startswith("'") and s.endswith("'")):
+        inner = s[1:-1]
+        return inner.replace('\\"', '"').replace("\\\\", "\\")
+
+    low = s.lower()
+    if low == "true":
+        return True
+    if low == "false":
+        return False
+    if low == "null":
+        return None
+
+    # Integer
+    try:
+        return int(s)
+    except ValueError:
+        pass
+
+    # Float
+    try:
+        return float(s)
+    except ValueError:
+        pass
+
+    return s
+
+
+# --- Config I/O ---
+
+def load_config(path):
+    """Load and parse config file. Returns dict."""
+    try:
+        with open(path) as f:
+            return load_yaml(f.read())
+    except FileNotFoundError:
+        print(f"Error: Config file not found: {path}", file=sys.stderr)
+        print("Run 'setup-config.py create' to create one.", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: Cannot parse config file: {path}", file=sys.stderr)
+        print(f"  {e}", file=sys.stderr)
+        print("Fix it manually or run 'setup-config.py create' to start fresh.", file=sys.stderr)
+        sys.exit(1)
+
+
+def write_config(path, config):
+    """Write config dict to YAML file. Creates parent dirs. Uses atomic write."""
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    text = dump_yaml(config)
+    # Atomic write: write to temp file then rename
+    fd, tmp_path = tempfile.mkstemp(dir=parent, suffix=".yaml.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp_path, path)
+    except Exception:
+        # Clean up temp file on failure
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# --- Helpers ---
+
+def suggest_account_id(email, existing_ids):
+    """Suggest account ID from email address."""
+    local = email.split("@")[0]
+    domain = email.split("@")[1].split(".")[0]
+    candidate = domain if domain in ("gmail", "outlook", "yahoo", "hotmail") else local
+    candidate = re.sub(r"[^a-z0-9-]", "", candidate.lower())
+    if not candidate:
+        candidate = "default"
+    if candidate not in existing_ids:
+        return candidate
+    for i in range(2, 100):
+        if f"{candidate}{i}" not in existing_ids:
+            return f"{candidate}{i}"
+    return candidate
+
+
+def detect_provider(email):
+    """Auto-detect provider from email domain."""
+    domain = email.split("@")[-1].lower()
+    return DOMAIN_PROVIDERS.get(domain)
+
+
+def build_account(args, existing_ids):
+    """Build an account dict from CLI flags. Validates and errors on missing fields."""
+    email = args.email
+
+    # Validate email
+    if "@" not in email or "." not in email.split("@")[-1]:
+        print(f"Error: Invalid email address: {email}", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve account ID
+    account_id = args.id if args.id else suggest_account_id(email, existing_ids)
+    account_id = account_id.lower()
+
+    if account_id in existing_ids:
+        print(f"Error: Account '{account_id}' already exists.", file=sys.stderr)
+        sys.exit(1)
+    if not ACCOUNT_ID_RE.match(account_id):
+        print("Error: Account ID must be lowercase alphanumeric with hyphens only.", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve provider
+    provider_key = args.provider if args.provider else detect_provider(email)
+    if provider_key is None:
+        provider_key = "generic"
+    if provider_key not in PROVIDERS:
+        print(f"Error: Unknown provider '{provider_key}'. Choose from: {', '.join(PROVIDERS.keys())}", file=sys.stderr)
+        sys.exit(1)
+
+    preset = PROVIDERS[provider_key]
+    account = {"id": account_id, "type": "imap"}
+
+    if provider_key == "generic":
+        if not args.imap_host:
+            print("Error: --imap-host is required for generic provider.", file=sys.stderr)
+            sys.exit(1)
+        if not args.smtp_host:
+            print("Error: --smtp-host is required for generic provider.", file=sys.stderr)
+            sys.exit(1)
+        account["host"] = args.imap_host
+        account["port"] = args.imap_port
+        account["ssl"] = not args.no_ssl
+        account["username"] = email
+        account["smtp_host"] = args.smtp_host
+        account["smtp_port"] = args.smtp_port
+        account["smtp_ssl"] = args.smtp_ssl
+    else:
+        account["host"] = preset["host"]
+        account["port"] = preset["port"]
+        account["ssl"] = preset["ssl"]
+        account["username"] = email
+        account["smtp_host"] = preset["smtp_host"]
+        account["smtp_port"] = preset["smtp_port"]
+        account["smtp_ssl"] = preset["smtp_ssl"]
+        if "sent_folder" in preset:
+            account["sent_folder"] = preset["sent_folder"]
+
+    # Permissions (read is always on)
+    account["permissions"] = {
+        "read": True,
+        "send": args.send,
+        "delete": args.delete,
+        "move": args.move,
+    }
+
+    # Per-account threshold
+    if args.threshold is not None:
+        account["protection"] = {"threshold": args.threshold}
+
+    return account
+
+
+def create_env_file(config_path, account_ids):
+    """Create .env file with password placeholders. Preserves existing values."""
+    env_path = os.path.join(os.path.dirname(config_path), ".env")
+
+    existing_vars = {}
+    if os.path.exists(env_path):
+        with open(env_path) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    key, _, val = line.partition("=")
+                    existing_vars[key.strip()] = val.strip()
+
+    new_lines = [
+        "# read-no-evil-mcp credentials",
+        "# !! Keep this file secret — do not commit to version control !!",
+    ]
+    for aid in account_ids:
+        var_name = f"RNOE_ACCOUNT_{aid.upper()}_PASSWORD"
+        val = existing_vars.get(var_name, "your-app-password-here")
+        new_lines.append(f"{var_name}={val}")
+
+    # Atomic write
+    parent = os.path.dirname(env_path)
+    fd, tmp_path = tempfile.mkstemp(dir=parent, suffix=".env.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write("\n".join(new_lines) + "\n")
+        os.replace(tmp_path, env_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    os.chmod(env_path, 0o600)
+    print(f"Created .env: {env_path}")
+
+
+# --- Subcommands ---
+
+def cmd_create(args):
+    """Create a new config file."""
+    if os.path.exists(args.config) and not args.force:
+        print(f"Error: Config file already exists: {args.config}", file=sys.stderr)
+        print("Use --force to overwrite.", file=sys.stderr)
+        sys.exit(1)
+
+    config = {
+        "protection": {"threshold": args.threshold},
+        "accounts": [],
+    }
+
+    write_config(args.config, config)
+    print(f"Config created: {args.config}")
+
+
+def cmd_add(args):
+    """Add an account to existing config."""
+    config = load_config(args.config)
+    accounts = config.get("accounts") or []
+    existing_ids = {a.get("id", "") for a in accounts}
+
+    account = build_account(args, existing_ids)
+    accounts.append(account)
+    config["accounts"] = accounts
+
+    write_config(args.config, config)
+
+    env_var = f"RNOE_ACCOUNT_{account['id'].upper()}_PASSWORD"
+    print(f"Account '{account['id']}' added to: {args.config}")
+    print(f"Set password env var: {env_var}")
+
+    if args.create_env:
+        account_ids = [a["id"] for a in accounts]
+        create_env_file(args.config, account_ids)
+
+
+def cmd_remove(args):
+    """Remove an account by ID."""
+    config = load_config(args.config)
+    accounts = config.get("accounts") or []
+    original_len = len(accounts)
+    new_accounts = [a for a in accounts if a.get("id") != args.account_id]
+
+    if len(new_accounts) == original_len:
+        print(f"Error: No account with ID '{args.account_id}'", file=sys.stderr)
+        sys.exit(1)
+
+    config["accounts"] = new_accounts
+    write_config(args.config, config)
+    print(f"Account '{args.account_id}' removed from config.")
+
+
+def cmd_list(args):
+    """List configured accounts."""
+    config = load_config(args.config)
+    accounts = config.get("accounts") or []
+    if not accounts:
+        print("No accounts configured.")
+        return
+    print(f"Accounts in {args.config}:")
+    for a in accounts:
+        host = a.get("host", "?")
+        user = a.get("username", "?")
+        print(f"  {a.get('id', '?'):12s} {user:30s} {host}")
+
+
+def cmd_show(args):
+    """Print the raw config file contents."""
+    try:
+        with open(args.config) as f:
+            print(f.read(), end="")
+    except FileNotFoundError:
+        print(f"Error: Config file not found: {args.config}", file=sys.stderr)
+        sys.exit(1)
+
+
+# --- Main ---
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Manage read-no-evil-mcp configuration (flag-driven, no interactive prompts)"
+    )
+    parser.add_argument(
+        "--config", default=DEFAULT_CONFIG, help="Config file path"
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # create
+    create_parser = subparsers.add_parser("create", help="Create config skeleton")
+    create_parser.add_argument("--threshold", type=float, default=0.5, help="Global protection threshold (default: 0.5)")
+    create_parser.add_argument("--force", action="store_true", help="Overwrite existing config")
+
+    # add
+    add_parser = subparsers.add_parser("add", help="Add an account")
+    add_parser.add_argument("--email", required=True, help="Email address (required)")
+    add_parser.add_argument("--id", default=None, help="Account ID (auto-generated from email if omitted)")
+    add_parser.add_argument("--provider", default=None, help="Provider: gmail, outlook, yahoo, generic (auto-detected if omitted)")
+    add_parser.add_argument("--send", action="store_true", default=False, help="Allow sending emails")
+    add_parser.add_argument("--delete", action="store_true", default=False, help="Allow deleting emails")
+    add_parser.add_argument("--move", action="store_true", default=False, help="Allow moving emails")
+    add_parser.add_argument("--threshold", type=float, default=None, help="Per-account protection threshold")
+    add_parser.add_argument("--imap-host", default=None, help="IMAP host (required for generic provider)")
+    add_parser.add_argument("--imap-port", type=int, default=993, help="IMAP port (default: 993)")
+    add_parser.add_argument("--smtp-host", default=None, help="SMTP host (required for generic provider)")
+    add_parser.add_argument("--smtp-port", type=int, default=587, help="SMTP port (default: 587)")
+    add_parser.add_argument("--no-ssl", action="store_true", default=False, help="Disable IMAP SSL")
+    add_parser.add_argument("--smtp-ssl", action="store_true", default=False, help="Enable SMTP SSL")
+    add_parser.add_argument("--create-env", action="store_true", default=False, help="Create .env with password placeholders")
+
+    # remove
+    remove_parser = subparsers.add_parser("remove", help="Remove an account")
+    remove_parser.add_argument("account_id", help="Account ID to remove")
+
+    # list / show
+    subparsers.add_parser("list", help="List configured accounts")
+    subparsers.add_parser("show", help="Print full config")
+
+    args = parser.parse_args()
+
+    commands = {
+        "create": cmd_create,
+        "add": cmd_add,
+        "remove": cmd_remove,
+        "list": cmd_list,
+        "show": cmd_show,
+    }
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-server.sh
+++ b/scripts/setup-server.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Pulls the official image, loads credentials from .env, and starts the server.
 # Designed for invocation by LLM agents (no interactive prompts).
 
-IMAGE="ghcr.io/thekie/read-no-evil-mcp:latest"
+IMAGE="ghcr.io/thekie/read-no-evil-mcp:0.3"
 
 # --- Defaults ---
 CONFIG=""

--- a/scripts/setup-server.sh
+++ b/scripts/setup-server.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Flag-driven setup for read-no-evil-mcp Docker container.
+# Pulls the official image, loads credentials from .env, and starts the server.
+# Designed for invocation by LLM agents (no interactive prompts).
+
+IMAGE="ghcr.io/thekie/read-no-evil-mcp:latest"
+
+# --- Defaults ---
+CONFIG=""
+ENV_FILE=""
+PORT=8000
+CONTAINER_NAME="rnoe-mcp"
+
+# --- Parse flags ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --config)   CONFIG="$2";         shift 2 ;;
+        --env-file) ENV_FILE="$2";       shift 2 ;;
+        --port)     PORT="$2";           shift 2 ;;
+        --name)     CONTAINER_NAME="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: setup-server.sh --config PATH --env-file PATH [--port 8000] [--name rnoe-mcp]"
+            echo
+            echo "Flags:"
+            echo "  --config    Config file path (required)"
+            echo "  --env-file  .env file with credentials (required)"
+            echo "  --port      Host port to bind (default: 8000)"
+            echo "  --name      Docker container name (default: rnoe-mcp)"
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown flag: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 1
+            ;;
+    esac
+done
+
+# --- Validate required flags ---
+if [ -z "$CONFIG" ]; then
+    echo "Error: --config is required." >&2
+    exit 1
+fi
+if [ -z "$ENV_FILE" ]; then
+    echo "Error: --env-file is required." >&2
+    exit 1
+fi
+if [ ! -f "$CONFIG" ]; then
+    echo "Error: Config file not found: $CONFIG" >&2
+    exit 1
+fi
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Error: .env file not found: $ENV_FILE" >&2
+    exit 1
+fi
+
+# --- Check Docker ---
+if ! command -v docker &>/dev/null; then
+    echo "Error: Docker is not installed. Please install Docker first." >&2
+    echo "  https://docs.docker.com/get-docker/" >&2
+    exit 1
+fi
+
+if ! docker info &>/dev/null 2>&1; then
+    echo "Error: Docker daemon is not running. Please start Docker." >&2
+    exit 1
+fi
+
+echo "Docker is ready."
+
+# --- Pull image ---
+echo "Pulling $IMAGE ..."
+docker pull "$IMAGE"
+
+# --- Load credentials from .env ---
+env_args=()
+while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%%#*}"  # strip comments
+    line="$(echo "$line" | xargs)"  # trim whitespace
+    if [[ "$line" == RNOE_ACCOUNT_*_PASSWORD=* ]]; then
+        env_args+=("-e" "$line")
+    fi
+done < "$ENV_FILE"
+echo "Loaded ${#env_args[@]} credential(s) from $ENV_FILE."
+
+# --- Stop existing container ---
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "Stopping existing $CONTAINER_NAME container..."
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+fi
+
+# --- Start container ---
+echo "Starting container..."
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    -p "${PORT}:8000" \
+    -v "$CONFIG:/app/rnoe.yaml:ro" \
+    -e RNOE_TRANSPORT=http \
+    "${env_args[@]}" \
+    "$IMAGE"
+
+# --- Health check ---
+echo "Waiting for server to start..."
+for i in $(seq 1 30); do
+    if curl -sf "http://localhost:${PORT}/mcp" -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"setup","version":"0.1.0"}}}' \
+        >/dev/null 2>&1; then
+        echo
+        echo "Server is ready!"
+        echo "  URL: http://localhost:${PORT}"
+        echo "  Container: $CONTAINER_NAME"
+        exit 0
+    fi
+    sleep 1
+    printf "."
+done
+
+echo
+echo "Warning: Server did not respond within 30 seconds." >&2
+echo "Check logs: docker logs $CONTAINER_NAME" >&2
+exit 1


### PR DESCRIPTION
## Summary

- Replace library-based integration with a Docker-hosted read-no-evil-mcp server accessed via the MCP Streamable HTTP protocol
- `rnoe-mail.py` rewritten as a standalone stdlib-only MCP HTTP client
- New `setup-config.py` — flag-driven config manager (no interactive prompts, designed for LLM agent invocation)
- New `setup-server.sh` — flag-driven Docker setup script (no interactive prompts)
- SKILL.md/README.md updated for the new Docker/HTTP architecture
- ClawHub → OpenClaw Hub rename in publish workflow

## Test plan

- [ ] `setup-config.py create && setup-config.py add --email test@gmail.com --send` creates valid config
- [ ] `setup-config.py list` / `setup-config.py remove` work without prompts
- [ ] `bash -n scripts/setup-server.sh` passes syntax check
- [ ] `python3 -c "import py_compile; py_compile.compile('scripts/setup-config.py', doraise=True)"` passes
- [ ] `rnoe-mail.py accounts` connects to a running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)