### PR TITLE
Convert --to and --cc to lists in send command

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -124,6 +124,7 @@ rnoe-mail.py read <uid>
 
 # Send email
 rnoe-mail.py send --to "user@example.com" --subject "Hello" --body "Message"
+rnoe-mail.py send --to "user1@example.com, user2@example.com" --cc "cc@example.com" --subject "Hello" --body "Message"
 
 # List folders
 rnoe-mail.py folders

--- a/scripts/rnoe-mail.py
+++ b/scripts/rnoe-mail.py
@@ -184,12 +184,12 @@ def cmd_read(client, args):
 def cmd_send(client, args):
     arguments = {
         "account": args.account,
-        "to": args.to,
+        "to": [x.strip() for x in args.to.split(",")],
         "subject": args.subject,
         "body": args.body,
     }
     if args.cc:
-        arguments["cc"] = args.cc
+        arguments["cc"] = [x.strip() for x in args.cc.split(",")]
     text, is_error = client.call_tool("send_email", arguments)
     if is_error:
         print(text, file=sys.stderr)


### PR DESCRIPTION
## Summary
- Split comma-separated `--to` and `--cc` strings into lists before sending to the MCP server, which expects list types
- Added multi-recipient example to SKILL.md

Fixes #4

## Test plan
- [ ] Send email with single recipient: `rnoe-mail.py send --to "user@example.com" --subject "Test" --body "Test"`
- [ ] Send email with multiple recipients: `rnoe-mail.py send --to "a@example.com, b@example.com" --subject "Test" --body "Test"`
- [ ] Send email with --cc: `rnoe-mail.py send --to "a@example.com" --cc "b@example.com, c@example.com" --subject "Test" --body "Test"`