### PR TITLE
Display unread indicator in list output

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -116,6 +116,7 @@ All commands accept `--server URL` to specify the MCP server (default: `http://l
 rnoe-mail.py accounts
 
 # List recent emails (last 30 days)
+# Output: [UID] ● DATE | SENDER | SUBJECT  (● = unread)
 rnoe-mail.py list
 rnoe-mail.py list --limit 10 --days 7 --account myaccount
 

--- a/scripts/rnoe-mail.py
+++ b/scripts/rnoe-mail.py
@@ -108,6 +108,20 @@ class McpClient:
 
     def call_tool(self, name, arguments=None):
         """Call an MCP tool. Returns (text, is_error)."""
+        result, is_error = self.call_tool_raw(name, arguments)
+        if isinstance(result, str):
+            return result, is_error
+
+        # Extract text from content array
+        texts = []
+        for item in result:
+            if item.get("type") == "text":
+                texts.append(item.get("text", ""))
+        text = "\n".join(texts) if texts else ""
+        return text, is_error
+
+    def call_tool_raw(self, name, arguments=None):
+        """Call an MCP tool. Returns (content_array, is_error) or (error_text, True)."""
         req = {
             "jsonrpc": "2.0",
             "id": self._next_id(),
@@ -122,15 +136,8 @@ class McpClient:
 
         result = resp.get("result", {})
         is_error = result.get("isError", False)
-
-        # Extract text from content array
         content = result.get("content", [])
-        texts = []
-        for item in content:
-            if item.get("type") == "text":
-                texts.append(item.get("text", ""))
-        text = "\n".join(texts) if texts else ""
-        return text, is_error
+        return content, is_error
 
     def close(self):
         """No persistent connection to close with HTTP transport."""
@@ -159,11 +166,41 @@ def cmd_list(client, args):
         arguments["limit"] = args.limit
     if args.days:
         arguments["days_back"] = args.days
-    text, is_error = client.call_tool("list_emails", arguments)
+    content, is_error = client.call_tool_raw("list_emails", arguments)
     if is_error:
-        print(text, file=sys.stderr)
+        error_text = content if isinstance(content, str) else str(content)
+        print(error_text, file=sys.stderr)
         sys.exit(1)
-    print(text)
+
+    # Try to parse structured JSON from text content items
+    emails = []
+    for item in content:
+        if item.get("type") == "text":
+            try:
+                parsed = json.loads(item["text"])
+                if isinstance(parsed, list):
+                    emails.extend(parsed)
+                elif isinstance(parsed, dict):
+                    emails.append(parsed)
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+    if emails and all("uid" in e for e in emails):
+        for email in emails:
+            uid = email.get("uid", "")
+            date = email.get("date", "")[:16]
+            sender = email.get("from", email.get("sender", ""))
+            subject = email.get("subject", "")
+            is_seen = email.get("is_seen", True)
+            indicator = " " if is_seen else "\u25cf"
+            print(f"[{uid}] {indicator} {date} | {sender} | {subject}")
+    else:
+        # Fallback: print raw text if not structured JSON
+        texts = []
+        for item in content:
+            if item.get("type") == "text":
+                texts.append(item.get("text", ""))
+        print("\n".join(texts) if texts else "")
 
 
 def cmd_read(client, args):


### PR DESCRIPTION
## Summary

- Add `call_tool_raw()` to `McpClient` for accessing structured MCP response content
- Parse `is_seen` from `list_emails` JSON response and display `●` for unread emails
- Fall back to raw text output when server returns non-JSON responses
- Document the unread indicator format in SKILL.md

Closes #6

## Output format

```
[32] ● 2026-02-16 13:04 | sender@example.com | Unread subject
[31]   2026-02-16 12:00 | sender@example.com | Read subject
```

## Test plan

- [ ] Verify `list` command shows `●` for unread emails and space for read ones
- [ ] Verify fallback works when server returns plain text instead of JSON
- [ ] Verify error handling still works (connection failures, invalid accounts)